### PR TITLE
Add Jadx Dex to Java Decompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Reverse Engineering
 28. [Simplify Android deobfuscator](https://github.com/CalebFenton/simplify)
 29. [Bytecode viewer](https://github.com/Konloch/bytecode-viewer)
 30. [Radare2](https://github.com/radare/radare2)
+31. [Jadx](https://github.com/skylot/jadx)
 
 Fuzz Testing
 ----


### PR DESCRIPTION
Adds Jadx to the reverse engineering list.