### PR TITLE
Adding appdetonator.run online tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A collection of android security related resources.
 26. ~~[Dexter](https://dexter.dexlabs.org/)~~
 27. ~~[MobiSec Eacus](http://www.mobiseclab.org/eacus.jsp)~~
 28. ~~[Fireeye](https://fireeye.ijinshan.com/)- max 60MB 15/day~~
+29. [App Detonator](https://appdetonator.run/) - Detonate APK binary to provide source code level details including app author, signature, build and manifest information. 3 Analysis/day free quota!
 
 ### Static Analysis Tools
 


### PR DESCRIPTION
Adding https://appdetonator.run online tool. Detonate APK binary to provide source code level details including app author, signature and build information. Can be used by malware analysts, researchers, developers to retrieve APK information using powerful REST APIs.