### PR TITLE
fix: ignore one more link

### DIFF
--- a/run_awesome_bot.sh
+++ b/run_awesome_bot.sh
@@ -34,7 +34,8 @@ DEAD_URLS='opencollective.com','http://copperdroid.isg.rhul.ac.uk/copperdroid/',
 'https://www.sec.tu-bs.de/~danarp/drebin/',\
 'https://apkpure.com',\
 'https://approver.talos-sec.com',\
-'https://wiki.sei.cmu.edu/confluence/display/android/Android+Secure+Coding+Standard'
+'https://wiki.sei.cmu.edu/confluence/display/android/Android+Secure+Coding+Standard',\
+'https://web.archive.org/web/20180721134044/http://www.fasteque.com:80/android-reverse-engineering-101-part-1/'
 
 FLAKY_URLS='http://safe.ijiami.cn/',\
 'https://apkcombo.com/apk-downloader/',\

--- a/run_awesome_bot.sh
+++ b/run_awesome_bot.sh
@@ -33,7 +33,8 @@ DEAD_URLS='opencollective.com','http://copperdroid.isg.rhul.ac.uk/copperdroid/',
 'https://www.nccgroup.trust/us/about-us/resources/intent-fuzzer/',\
 'https://www.sec.tu-bs.de/~danarp/drebin/',\
 'https://apkpure.com',\
-'https://approver.talos-sec.com'
+'https://approver.talos-sec.com',\
+'https://wiki.sei.cmu.edu/confluence/display/android/Android+Secure+Coding+Standard'
 
 FLAKY_URLS='http://safe.ijiami.cn/',\
 'https://apkcombo.com/apk-downloader/',\


### PR DESCRIPTION
Cert verification of https://wiki.sei.cmu.edu/confluence/display/android/Android+Secure+Coding+Standard fails on GitHub Actions