### PR TITLE
Add NullKia mobile security framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ A collection of Android security-related resources.
 1. [AppMon](https://github.com/dpnishant/appmon)- AppMon is an automated framework for monitoring and tampering with system API calls of native macOS, iOS, and Android apps. It is based on Frida.
 1. [Internal Blue](https://github.com/seemoo-lab/internalblue) - Bluetooth experimentation framework based on the Reverse Engineering of Broadcom Bluetooth Controllers
 1. [Android Mobile Device Hardening](https://github.com/SecTheTech/AMDH) - AMDH scans and hardens the device's settings and lists harmful installed Apps based on permissions.
+1. [NullKia](https://github.com/bad-antics/nullkia) - Comprehensive mobile security framework supporting 18 manufacturers with baseband exploitation, cellular security, TEE/TrustZone research, and BootROM extraction tools.
 1. [Firmware Extractor](https://github.com/AndroidDumps/Firmware_extractor) - Extract given archive to images
 1. [ARMv7 payload that provides arbitrary code execution on MediaTek bootloaders](https://github.com/R0rt1z2/kaeru)  
 1. [DroidGround](https://github.com/SECFORCE/droidground) - A flexible playground for Android CTF challenges


### PR DESCRIPTION
## Description
Adds [NullKia](https://github.com/bad-antics/nullkia) to the Misc Tools section.

## About NullKia
A comprehensive mobile security framework featuring:
- **18 Manufacturer Support**: Samsung, Apple, Google, OnePlus, Xiaomi, Huawei, Motorola, LG, Sony, Nokia, Nothing, OPPO, Vivo, Realme, ASUS, ZTE, Fairphone, TCL
- **Baseband Exploitation**: Shannon, Qualcomm, MediaTek, Exynos, Apple modem tools
- **Cellular Security**: 5G/LTE security, eSIM tools, IMSI analysis, carrier unlock
- **TEE/TrustZone**: Secure Element research, BootROM extraction
- **GUI & Plugins**: Interactive dashboard with extensible plugin architecture

## Checklist
- [x] Searched for duplicates
- [x] Contributions welcome per CONTRIBUTING.md
- [x] Uses numbered list format matching existing entries