### PR TITLE
ci: make markdown linting stricter

### DIFF
--- a/.github/workflows/lint-markdown.yaml
+++ b/.github/workflows/lint-markdown.yaml
@@ -47,5 +47,4 @@ jobs:
       - name: Run tests
         # Rule list: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md
         # Don't check for line length (MD013)
-        # Don't care about list ordering (MD029)
-        run: mdl --git-recurse --rules ~MD013,~MD029 .
+        run: mdl --git-recurse --rules ~MD013


### PR DESCRIPTION
Ref: https://github.com/ashishb/android-security-awesome/issues/295